### PR TITLE
Remove layout from core handles

### DIFF
--- a/paygate/paygate-payweb-gateway/view/frontend/layout/checkout_index_index.xml
+++ b/paygate/paygate-payweb-gateway/view/frontend/layout/checkout_index_index.xml
@@ -8,7 +8,7 @@
  * Released under the GNU General Public License
  */
 -->
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column"
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
         <css src="PayGate_PayWeb::css/paygate_checkout.css"/>

--- a/paygate/paygate-payweb-gateway/view/frontend/layout/default.xml
+++ b/paygate/paygate-payweb-gateway/view/frontend/layout/default.xml
@@ -8,7 +8,7 @@
  * Released under the GNU General Public License
  */
 -->
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="1column"
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
       xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <head>
         <css src="PayGate_PayWeb::css/paygate_checkout.css"/>


### PR DESCRIPTION
You as a third party extension should not modify the layout of core handles. This can lead to unexpected behaviour. You should just inherit the core layout. Since XML files are merged, defining no layout at all is the right way to go.